### PR TITLE
Add DataFrame JSON output for executions

### DIFF
--- a/text_to_pydough/app.py
+++ b/text_to_pydough/app.py
@@ -755,6 +755,7 @@ def process_query_langgraph():
             "domain": final_state.get("domain", "Unknown"),
             "pydough_code": pydough_code,
             "execution": execution_result if execution_result else None,
+            "pandas_df_json": execution_result.get("pandas_df_json") if execution_result else None,
             "messages": messages,
             "timestamp": datetime.now().isoformat()
         }


### PR DESCRIPTION
## Summary
- include DataFrame JSON output in generated scripts
- parse PD_JSON output during script execution
- return `pandas_df_json` from `process_query`
- expose parsed DataFrame JSON via LangGraph endpoint

## Testing
- `python3 -m py_compile text_to_pydough/pydough_query_processor.py text_to_pydough/app.py`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*