### PR TITLE
Add backend env example and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ explore next, see
         deactivate
         cd .. # Return to project root
         ```
-    *   Alternatively, the application *may* fall back to an environment variable `GEMINI_API_KEY` if set in `text_to_pydough/.env`, but using `llm keys set gemini` is recommended.
+    *   Alternatively, you can copy `text_to_pydough/.env.example` to `text_to_pydough/.env` and set your `GEMINI_API_KEY` there (you may also change `PORT` to run on a different port). Using `llm keys set gemini` is still recommended.
 
 5.  **(Optional) Configure API Base URL:**
     If your backend runs on a different host or port, create a `.env` file in

--- a/text_to_pydough/.env.example
+++ b/text_to_pydough/.env.example
@@ -1,0 +1,2 @@
+GEMINI_API_KEY=your_key_here
+PORT=5001   # optional


### PR DESCRIPTION
## Summary
- add example environment file for backend
- mention `.env.example` when configuring the backend API key

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*